### PR TITLE
Bugfix: package.json wasn't valid JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
    "bugs": {
      "web" : "http://github.com/plotnikoff/vcdiff.js/issues"
    },
-   keywords: ['vcdiff','diff','compression','rfc3229','rfc3284']
+   "keywords": ["vcdiff","diff","compression","rfc3229","rfc3284"]
 }


### PR DESCRIPTION
This module isn't in the NPM registry right now.  I'm trying to avoid including vcdiff.js directly in an upcoming project, but even `npm install https://github.com/plotnikoff/vcdiff.js.git` fails because of this JSON error.
